### PR TITLE
feat: implement TaskLoop library with while loop structure

### DIFF
--- a/src/lib/TaskLoop/TaskLoop.ts
+++ b/src/lib/TaskLoop/TaskLoop.ts
@@ -1,0 +1,118 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { type Message, type TaskLoopConfig, type TaskLoopCallbacks, type TaskLoopState } from './types';
+import { generateSystemPrompt } from './systemPrompt';
+
+export class TaskLoop {
+  private anthropic: Anthropic;
+  private config: TaskLoopConfig;
+  private conversationHistory: Message[] = [];
+  private state: TaskLoopState = {
+    isRunning: false,
+    currentIteration: 0,
+    shouldStop: false
+  };
+
+  constructor(config: TaskLoopConfig) {
+    this.config = {
+      model: 'claude-3-5-sonnet-20241022',
+      maxTokens: 1000,
+      ...config
+    };
+
+    this.anthropic = new Anthropic({
+      apiKey: this.config.apiKey,
+      dangerouslyAllowBrowser: true
+    });
+  }
+
+  async sendMessage(message: string, callbacks: TaskLoopCallbacks = {}): Promise<void> {
+    if (this.state.isRunning) {
+      throw new Error('TaskLoop is already running');
+    }
+
+    try {
+      // Add user message to conversation history
+      const userMessage: Message = { role: 'user', content: message };
+      this.conversationHistory.push(userMessage);
+
+      // Start the task loop
+      await this.createTaskLoop(userMessage, callbacks);
+    } catch (error) {
+      callbacks.onError?.(error as Error);
+      throw error;
+    }
+  }
+
+  private async createTaskLoop(initialMessage: Message, callbacks: TaskLoopCallbacks): Promise<void> {
+    this.state.isRunning = true;
+    this.state.currentIteration = 0;
+    this.state.shouldStop = false;
+
+    // Task loop with while structure as requested
+    while (!this.state.shouldStop) {
+      this.state.currentIteration++;
+
+      try {
+        // Send AI prompt with conversation history and system prompt
+        const stream = await this.anthropic.messages.stream({
+          model: this.config.model!,
+          max_tokens: this.config.maxTokens!,
+          system: generateSystemPrompt(),
+          messages: this.conversationHistory.map(msg => ({
+            role: msg.role,
+            content: msg.content
+          }))
+        });
+
+        let fullContent = '';
+
+        // Process streaming response
+        for await (const chunk of stream) {
+          if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
+            fullContent += chunk.delta.text;
+            // Call streaming update callback
+            callbacks.onStreamingUpdate?.(fullContent);
+          }
+        }
+
+        // Create assistant message
+        const assistantMessage: Message = {
+          role: 'assistant', 
+          content: fullContent || 'エラーが発生しました'
+        };
+
+        // Add to conversation history
+        this.conversationHistory.push(assistantMessage);
+
+        // Call completion callback
+        callbacks.onComplete?.(assistantMessage);
+
+        // For this simplified version, always assume completion tool was executed
+        // This simulates the "attempt_completion" tool being found
+        this.state.shouldStop = true;
+
+      } catch (error) {
+        this.state.shouldStop = true;
+        throw error;
+      }
+    }
+
+    this.state.isRunning = false;
+  }
+
+  getConversationHistory(): Message[] {
+    return [...this.conversationHistory];
+  }
+
+  clearHistory(): void {
+    this.conversationHistory = [];
+  }
+
+  isRunning(): boolean {
+    return this.state.isRunning;
+  }
+
+  getCurrentIteration(): number {
+    return this.state.currentIteration;
+  }
+}

--- a/src/lib/TaskLoop/index.ts
+++ b/src/lib/TaskLoop/index.ts
@@ -1,0 +1,10 @@
+// TaskLoop library exports
+
+export { TaskLoop } from './TaskLoop';
+export { generateSystemPrompt } from './systemPrompt';
+export type { 
+  Message, 
+  TaskLoopConfig, 
+  TaskLoopCallbacks, 
+  TaskLoopState 
+} from './types';

--- a/src/lib/TaskLoop/systemPrompt.ts
+++ b/src/lib/TaskLoop/systemPrompt.ts
@@ -1,0 +1,20 @@
+// System prompt generation for TaskLoop
+
+export function generateSystemPrompt(): string {
+  return `You are an AI assistant specialized in data analysis using DuckDB. You have access to a DuckDB instance that can process SQL queries on various data sources.
+
+Your capabilities include:
+- Analyzing datasets loaded into DuckDB tables
+- Writing and executing SQL queries  
+- Providing insights about data structure and content
+- Helping with geospatial data analysis
+- Answering questions about data patterns and relationships
+
+When responding:
+- Be clear and concise in your explanations
+- Provide SQL examples when relevant
+- Explain your reasoning for data analysis approaches
+- Suggest further analysis when appropriate
+
+Always assume you have completed your task after providing a response.`;
+}

--- a/src/lib/TaskLoop/types.ts
+++ b/src/lib/TaskLoop/types.ts
@@ -1,0 +1,24 @@
+// Types for TaskLoop library
+
+export interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface TaskLoopConfig {
+  apiKey: string;
+  model?: string;
+  maxTokens?: number;
+}
+
+export interface TaskLoopCallbacks {
+  onStreamingUpdate?: (content: string) => void;
+  onComplete?: (finalMessage: Message) => void;
+  onError?: (error: Error) => void;
+}
+
+export interface TaskLoopState {
+  isRunning: boolean;
+  currentIteration: number;
+  shouldStop: boolean;
+}


### PR DESCRIPTION
This PR implements a TaskLoop library with the requested while loop structure that runs once and assumes completion after the first iteration.

## Changes

- Add TaskLoop library in `src/lib/TaskLoop/` as @anthropic-ai/sdk wrapper
- Implement `createTaskLoop()` with while loop that runs once
- Add `generateSystemPrompt()` function for AI context
- Update AIChat component to use TaskLoop with callbacks
- Loop assumes completion tool executed after first iteration
- Maintain streaming response functionality and error handling

## Key While Loop Implementation

The TaskLoop now includes a proper `while (!this.state.shouldStop)` loop inside `createTaskLoop()` that:
1. Executes AI streaming response
2. Automatically sets `shouldStop = true` to simulate completion tool execution
3. Exits after first iteration as requested

## Testing

- All existing tests continue to pass (10/10)
- No lint issues in new TaskLoop library files
- TypeScript typing properly implemented throughout
- Syntax errors resolved

Fixes #5

Generated with [Claude Code](https://claude.ai/code)